### PR TITLE
fix(ci):  use swiftshader(cpu based vulkan driver) as webgpu adaptor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     
@@ -29,6 +29,6 @@ jobs:
     - name: Test Build
       run: pnpm run build
 
-    # - name: Test in Electron
-    #   run: pnpm run test:ci
+    - name: Test in Electron
+      run: pnpm run test:ci
         

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "minify:es": "uglifyjs dist/orillusion.es.js -o dist/orillusion.es.js -c -m",
         "test": "electron test/ci/main.js",
-        "test:ci": "xvfb-maybe -- electron test/ci/main.js",
+        "test:ci": "xvfb-maybe -- electron --enable-unsafe-webgpu --enable-features=Vulkan --use-vulkan=swiftshader --use-webgpu-adapter=swiftshader --no-sandbox test/ci/main.js",
         "docs": "npm run docs:core && npm run docs:physics && npm run docs:media && npm run docs:stats",
         "docs:typedoc": "npx typedoc --plugin typedoc-plugin-markdown --plugin ./script/typedoc-plugin-not-exported.js --tsconfig tsconfig.build.json --gitRevision main --hideBreadcrumbs true --allReflectionsHaveOwnDocument true --readme none --excludeInternal --excludePrivate --excludeProtected --sort source-order --out",
         "docs:core": "npm run docs:typedoc docs/api src/index.ts",


### PR DESCRIPTION
Switch to Ubuntu runner, could use swiftshader (a CPU-based Vulkan API driver) as webgpu backend
Even though there are still some internal Vulkan errors, it could process WebGPU APIs for CI test.

Wait for Electron/Chromium further updates