### PR TITLE
fix(loader): fix unnecessary memory copy

### DIFF
--- a/src/loader/parser/b3dm/B3DMLoaderBase.ts
+++ b/src/loader/parser/b3dm/B3DMLoaderBase.ts
@@ -39,27 +39,19 @@ export class B3DMLoaderBase  {
 
         // Feature Table
         const featureTableStart = 28;
-        const featureTableBuffer = buffer.slice(
-            featureTableStart,
-            featureTableStart + featureTableJSONByteLength + featureTableBinaryByteLength,
-        );
         const featureTable = new FeatureTable(
-            featureTableBuffer,
-            0,
+            buffer,
+            featureTableStart,
             featureTableJSONByteLength,
             featureTableBinaryByteLength,
         );
 
         // Batch Table
         const batchTableStart = featureTableStart + featureTableJSONByteLength + featureTableBinaryByteLength;
-        const batchTableBuffer = buffer.slice(
-            batchTableStart,
-            batchTableStart + batchTableJSONByteLength + batchTableBinaryByteLength,
-        );
         const batchTable = new BatchTable(
-            batchTableBuffer,
+            buffer,
             featureTable.getData( 'BATCH_LENGTH' ),
-            0,
+            batchTableStart,
             batchTableJSONByteLength,
             batchTableBinaryByteLength,
         );

--- a/src/loader/parser/i3dm/I3DMLoaderBase.ts
+++ b/src/loader/parser/i3dm/I3DMLoaderBase.ts
@@ -41,27 +41,19 @@ export class I3DMLoaderBase {
 
         // Feature Table
         const featureTableStart = 32;
-        const featureTableBuffer = buffer.slice(
-            featureTableStart,
-            featureTableStart + featureTableJSONByteLength + featureTableBinaryByteLength,
-        );
         const featureTable = new FeatureTable(
-            featureTableBuffer,
-            0,
+            buffer,
+            featureTableStart,
             featureTableJSONByteLength,
             featureTableBinaryByteLength,
         );
 
         // Batch Table
         const batchTableStart = featureTableStart + featureTableJSONByteLength + featureTableBinaryByteLength;
-        const batchTableBuffer = buffer.slice(
-            batchTableStart,
-            batchTableStart + batchTableJSONByteLength + batchTableBinaryByteLength,
-        );
         const batchTable = new BatchTable(
-            batchTableBuffer,
+            buffer,
             featureTable.getData('INSTANCES_LENGTH'),
-            0,
+            batchTableStart,
             batchTableJSONByteLength,
             batchTableBinaryByteLength,
         );


### PR DESCRIPTION
fix unnecessary memory copy in ```B3DMLoaderBase``` and ```I3DMLoaderBase```