### PR TITLE
fix(sprite): 修复 BillboardY 垂直视角下左右甩动 (fix #504)

### DIFF
--- a/src/components/BillboardComponent.ts
+++ b/src/components/BillboardComponent.ts
@@ -54,10 +54,24 @@ export class BillboardComponent extends ComponentBase {
         if (this.type == BillboardType.BillboardXYZ) {
         } else if (this.type == BillboardType.BillboardY) {
             this._cameraPosition.y = 0;
+
+            // A cylindrical billboard has no defined yaw when the camera is
+            // looking straight up or down. Normalizing that near-zero XZ
+            // projection amplifies floating-point noise and makes the sprite
+            // swing between opposite directions as the camera rotates.
+            // Keep the last valid orientation until a horizontal camera
+            // direction is available again.
+            const horizontalLengthSquared =
+                this._cameraPosition.x * this._cameraPosition.x +
+                this._cameraPosition.z * this._cameraPosition.z;
+            if (horizontalLengthSquared <= Vector3.EPSILON * Vector3.EPSILON) return;
         }
         this._cameraPosition.normalize();
         Vector3.add(this._cameraPosition, this.object3D.localPosition, this._cameraPosition);
-        this.transform.lookAt(this.object3D.localPosition, this._cameraPosition, camera.transform.up);
+        // BillboardY must stay locked to the world Y axis. Using the camera's
+        // up vector introduces roll and becomes unstable at a vertical view.
+        const up = this.type == BillboardType.BillboardY ? Vector3.Y_AXIS : camera.transform.up;
+        this.transform.lookAt(this.object3D.localPosition, this._cameraPosition, up);
     }
 
     /**


### PR DESCRIPTION
## 问题描述

当 Sprite 使用 `BillboardType.BillboardY` 时，如果相机从 Sprite 的正上方或正下方观察，旋转相机会导致 Sprite 出现明显的左右甩动或朝向跳变。

这是因为 BillboardY 会将相机朝向投影到 XZ 平面。当相机垂直观察时，该投影接近零向量，归一化操作会放大浮点误差。同时，原实现使用相机自身的 `up` 向量，使 Sprite 的朝向受到相机旋转影响。

## 复现步骤

1. 创建一个 Sprite。
2. 添加 `BillboardComponent`。
3. 将 Billboard 类型设置为 `BillboardType.BillboardY`。
4. 将相机移动到 Sprite 的正上方或正下方，并朝向 Sprite。
5. 旋转相机。
6. 可以观察到 Sprite 左右甩动或发生朝向跳变。

## 预期行为

使用 `BillboardType.BillboardY` 时：

- Sprite 始终保持世界 Y 轴竖直。
- 相机垂直观察时，Sprite 不应因微小的浮点误差产生左右甩动。
- 相机恢复有效的水平方向后，Sprite 应继续正常朝向相机。

## 修改内容

- 在归一化相机朝向前检查 XZ 平面的投影长度。
- 当水平投影接近零时，保留 Sprite 上一次有效朝向。
- BillboardY 使用固定的世界 Y 轴作为向上方向，避免受到相机滚转影响。
- `BillboardXYZ` 和 `BillboardType.None` 的行为保持不变。
- 未修改公共 API。

## 验证

已完成以下检查：

- TypeScript 类型检查通过：
  `tsc --noEmit -p tsconfig.build.json`
- `git diff --check` 通过。

## 影响范围

本次修改仅影响 `BillboardType.BillboardY` 在垂直或接近垂直视角下的朝向计算，不影响其他 Billboard 模式。

## 效果对比

### 修复前

相机从 Sprite 的垂直方向观察并旋转时，Sprite 会出现左右甩动。
<img width="1280" height="720" alt="ezgif-3ef33e171e00f34f" src="https://github.com/user-attachments/assets/66d93278-dd01-4e3d-b966-5faed579283c" />


### 修复后

相同操作下，Sprite 保持稳定，不再出现左右甩动。

<img width="800" height="450" alt="ezgif-8b38602538eecc0c" src="https://github.com/user-attachments/assets/70b2ab2a-74ad-432b-8183-f239a8416045" />


